### PR TITLE
Convert module role hats to mutable

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,22 +4,22 @@ A [Hats Protocol](https://github.com/hats-protocol/hats-protocol) eligibility mo
 
 ## Overview and Usage
 
-This module sets up a simple allowlist to determine eligibility for a hat. For a given account (i.e., potential hat wearer), the allowlist stores values for that account's eligibility and standing for the hat. The wearer(s) of the `OWNER_HAT` can add or remove accounts from the allowlist. The wearer(s) of the `ARBITRATOR_HAT` can set the standing of accounts.
+This module sets up a simple allowlist to determine eligibility for a hat. For a given account (i.e., potential hat wearer), the allowlist stores values for that account's eligibility and standing for the hat. The wearer(s) of the `ownerHat` can add or remove accounts from the allowlist. The wearer(s) of the `arbitrator` can set the standing of accounts.
 
 This module serves as both a "mechanistic" and "humanistic passthrough" eligibility module.
 
 ### Mechanistic Functionality
 
-- Wearer(s) of the `OWNER_HAT` can simply add account(s) to the allowlist by calling `addAccount()` or `addAccounts()`.
-- Wearer(s) of the `OWNER_HAT` can simply remove account(s) from the allowlist by calling `removeAccount()` or `removeAccounts()`.
-- Wearer(s) of the `ARBITRATOR_HAT` can simply set the standing of account(s) by calling `setStandingForAccount()` or `setStandingForAccounts()`.
+- Wearer(s) of the `ownerHat` can simply add account(s) to the allowlist by calling `addAccount()` or `addAccounts()`.
+- Wearer(s) of the `ownerHat` can simply remove account(s) from the allowlist by calling `removeAccount()` or `removeAccounts()`.
+- Wearer(s) of the `arbitrator` can simply set the standing of account(s) by calling `setStandingForAccount()` or `setStandingForAccounts()`.
 
 In each of these cases, Hats Protocol will *pull* eligibility and standing data from the module via `getWearerStatus()`. Hats Protocol will not emit an event with any of these eligibility and resulting wearer changes, so front ends pointing only at Hats Protocol events (or the [subgraph](https://github.com/hats-protocol/subgraph)) will not automatically reclect these changes.
 
 ### Humanistic Functionality
 
-- Wearer(s) of the `OWNER_HAT` can manually revoke an account's hat by calling `removeAccountAndBurnHat()`.
-- Wearer(s) of the `ARBITRATOR_HAT` can manually put an account in bad standing and burn their hat `setStandingForAccountAndBurnHat()`.
+- Wearer(s) of the `ownerHat` can manually revoke an account's hat by calling `removeAccountAndBurnHat()`.
+- Wearer(s) of the `arbitrator` can manually put an account in bad standing and burn their hat `setStandingForAccountAndBurnHat()`.
 
 In these cases, the module *pushes* eligibility and standing data to Hats Protocol, causing Hats Protocol to emit event(s) reflecting the eligibility and resulting wearer changes. Front ends pointing at Hats Protocol events (or the subgaph) *will* automatically reflect these changes.
 

--- a/README.md
+++ b/README.md
@@ -6,16 +6,18 @@ A [Hats Protocol](https://github.com/hats-protocol/hats-protocol) eligibility mo
 
 This module sets up a simple allowlist to determine eligibility for a hat. For a given account (i.e., potential hat wearer), the allowlist stores values for that account's eligibility and standing for the hat. The wearer(s) of the `OWNER_HAT` can add or remove accounts from the allowlist. The wearer(s) of the `ARBITRATOR_HAT` can set the standing of accounts.
 
-This module serves as both a "mechanistic" and "humanistic passthrough" eligibility module. 
+This module serves as both a "mechanistic" and "humanistic passthrough" eligibility module.
 
 ### Mechanistic Functionality
+
 - Wearer(s) of the `OWNER_HAT` can simply add account(s) to the allowlist by calling `addAccount()` or `addAccounts()`.
 - Wearer(s) of the `OWNER_HAT` can simply remove account(s) from the allowlist by calling `removeAccount()` or `removeAccounts()`.
 - Wearer(s) of the `ARBITRATOR_HAT` can simply set the standing of account(s) by calling `setStandingForAccount()` or `setStandingForAccounts()`.
 
 In each of these cases, Hats Protocol will *pull* eligibility and standing data from the module via `getWearerStatus()`. Hats Protocol will not emit an event with any of these eligibility and resulting wearer changes, so front ends pointing only at Hats Protocol events (or the [subgraph](https://github.com/hats-protocol/subgraph)) will not automatically reclect these changes.
 
-### Humanistic Functionality 
+### Humanistic Functionality
+
 - Wearer(s) of the `OWNER_HAT` can manually revoke an account's hat by calling `removeAccountAndBurnHat()`.
 - Wearer(s) of the `ARBITRATOR_HAT` can manually put an account in bad standing and burn their hat `setStandingForAccountAndBurnHat()`.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A [Hats Protocol](https://github.com/hats-protocol/hats-protocol) eligibility mo
 
 ## Overview and Usage
 
-This module sets up a simple allowlist to determine eligibility for a hat. For a given account (i.e., potential hat wearer), the allowlist stores values for that account's eligibility and standing for the hat. The wearer(s) of the `ownerHat` can add or remove accounts from the allowlist. The wearer(s) of the `arbitrator` can set the standing of accounts.
+This module sets up a simple allowlist to determine eligibility for a hat. For a given account (i.e., potential hat wearer), the allowlist stores values for that account's eligibility and standing for the hat. The wearer(s) of the `ownerHat` can add or remove accounts from the allowlist. The wearer(s) of the `arbitratorHat` can set the standing of accounts.
 
 This module serves as both a "mechanistic" and "humanistic passthrough" eligibility module.
 
@@ -12,16 +12,16 @@ This module serves as both a "mechanistic" and "humanistic passthrough" eligibil
 
 - Wearer(s) of the `ownerHat` can simply add account(s) to the allowlist by calling `addAccount()` or `addAccounts()`.
 - Wearer(s) of the `ownerHat` can simply remove account(s) from the allowlist by calling `removeAccount()` or `removeAccounts()`.
-- Wearer(s) of the `arbitrator` can simply set the standing of account(s) by calling `setStandingForAccount()` or `setStandingForAccounts()`.
+- Wearer(s) of the `arbitratorHat` can simply set the standing of account(s) by calling `setStandingForAccount()` or `setStandingForAccounts()`.
 
-In each of these cases, Hats Protocol will *pull* eligibility and standing data from the module via `getWearerStatus()`. Hats Protocol will not emit an event with any of these eligibility and resulting wearer changes, so front ends pointing only at Hats Protocol events (or the [subgraph](https://github.com/hats-protocol/subgraph)) will not automatically reclect these changes.
+In each of these cases, Hats Protocol will *pull* eligibility and standing data from the module via `getWearerStatus()`. Hats Protocol will not emit an event with any of these eligibility and resulting wearer changes, so front ends pointing only at Hats Protocol events (or the [subgraph](https://github.com/hats-protocol/subgraph)) will not automatically reflect these changes.
 
 ### Humanistic Functionality
 
 - Wearer(s) of the `ownerHat` can manually revoke an account's hat by calling `removeAccountAndBurnHat()`.
-- Wearer(s) of the `arbitrator` can manually put an account in bad standing and burn their hat `setStandingForAccountAndBurnHat()`.
+- Wearer(s) of the `arbitratorHat` can manually put an account in bad standing and burn their hat `setStandingForAccountAndBurnHat()`.
 
-In these cases, the module *pushes* eligibility and standing data to Hats Protocol, causing Hats Protocol to emit event(s) reflecting the eligibility and resulting wearer changes. Front ends pointing at Hats Protocol events (or the subgaph) *will* automatically reflect these changes.
+In these cases, the module *pushes* eligibility and standing data to Hats Protocol, causing Hats Protocol to emit event(s) reflecting the eligibility and resulting wearer changes. Front ends pointing at Hats Protocol events (or the subgraph) *will* automatically reflect these changes.
 
 ## Development
 

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -6,7 +6,7 @@ import { AllowlistEligibility } from "../src/AllowlistEligibility.sol";
 
 contract Deploy is Script {
   AllowlistEligibility public implementation;
-  bytes32 public SALT = bytes32(abi.encode("change this to the value of your choice"));
+  bytes32 public SALT = bytes32(abi.encode(0x4a75));
 
   // default values
   bool internal _verbose = true;
@@ -42,7 +42,7 @@ contract Deploy is Script {
      *       never differs regardless of where its being compiled
      *    2. The provided salt, `SALT`
      */
-    implementation = new AllowlistEligibility{ salt: SALT}(_version /* insert constructor args here */);
+    implementation = new AllowlistEligibility{ salt: SALT }(_version /* insert constructor args here */ );
 
     vm.stopBroadcast();
 

--- a/src/AllowlistEligibility.sol
+++ b/src/AllowlistEligibility.sol
@@ -331,7 +331,7 @@ contract AllowlistEligibility is HatsEligibilityModule {
 
   /**
    * @notice Set a new arbitrator hat
-   * @dev Only callable by a wearer of the current arbitratorHat, and only if the target hat is mutable
+   * @dev Only callable by a wearer of the current ownerHat, and only if the target hat is mutable
    * @param _newArbitratorHat The new arbitrator hat
    */
   function setArbitratorHat(uint256 _newArbitratorHat) public onlyOwner hatIsMutable {
@@ -364,7 +364,7 @@ contract AllowlistEligibility is HatsEligibilityModule {
    * @dev Set a new owner hat
    * @param _newOwnerHat The new owner hat
    */
-  function _setOwnerHat(uint256 _newOwnerHat) public {
+  function _setOwnerHat(uint256 _newOwnerHat) internal {
     ownerHat = _newOwnerHat;
 
     emit OwnerHatSet(_newOwnerHat);
@@ -374,7 +374,7 @@ contract AllowlistEligibility is HatsEligibilityModule {
    * @dev Set a new arbitrator hat
    * @param _newArbitratorHat The new arbitrator hat
    */
-  function _setArbitratorHat(uint256 _newArbitratorHat) public {
+  function _setArbitratorHat(uint256 _newArbitratorHat) internal {
     arbitratorHat = _newArbitratorHat;
 
     emit ArbitratorHatSet(_newArbitratorHat);

--- a/src/AllowlistEligibility.sol
+++ b/src/AllowlistEligibility.sol
@@ -8,9 +8,9 @@ import { HatsEligibilityModule, HatsModule, IHatsEligibility } from "hats-module
                             CUSTOM ERRORS
 //////////////////////////////////////////////////////////////*/
 
-/// @dev Thrown when the caller does not wear the `OWNER_HAT`
+/// @dev Thrown when the caller does not wear the `ownerHat`
 error AllowlistEligibility_NotOwner();
-/// @dev Thrown when the caller does not wear the `ARBITRATOR_HAT`
+/// @dev Thrown when the caller does not wear the `arbitratorHat`
 error AllowlistEligibility_NotArbitrator();
 /// @dev Thrown when array args are not the same length
 error AllowlistEligibility_ArrayLengthMismatch();
@@ -176,7 +176,7 @@ contract AllowlistEligibility is HatsEligibilityModule {
 
   /**
    * @notice Add an account to the allowlist
-   * @dev Only callable by a wearer of the OWNER_HAT
+   * @dev Only callable by a wearer of the ownerHat
    *      Does not revert if account is already added; overwrites existing eligibility data for the account
    * @param _account The account to add
    */
@@ -188,7 +188,7 @@ contract AllowlistEligibility is HatsEligibilityModule {
 
   /**
    * @notice Add multiple accounts to the allowlist
-   * @dev Only callable by a wearer of the OWNER_HAT
+   * @dev Only callable by a wearer of the ownerHat
    *      Does not revert if an account is already added; overwrites existing eligibility data for the account
    * @param _accounts The array of accounts to add
    */
@@ -205,7 +205,7 @@ contract AllowlistEligibility is HatsEligibilityModule {
 
   /**
    * @notice Remove an account from the allowlist
-   * @dev Only callable by a wearer of the OWNER_HAT
+   * @dev Only callable by a wearer of the ownerHat
    *      Does not revert if account is not yet added
    *      Revokes the account's hat if they are wearing it, but no burn event will be emitted
    * @param _account The account to remove
@@ -218,7 +218,7 @@ contract AllowlistEligibility is HatsEligibilityModule {
 
   /**
    * @notice Remove an account from the allowlist and revoke their hat
-   * @dev Only callable by a wearer of the OWNER_HAT
+   * @dev Only callable by a wearer of the ownerHat
    *      Will revert if the account is not wearing the hat
    *      Reverts if the account is not wearing the hat, but other does not revert if account is not yet added
    * @param _account The account to remove
@@ -245,7 +245,7 @@ contract AllowlistEligibility is HatsEligibilityModule {
 
   /**
    * @notice Remove multiple accounts from the allowlist
-   * @dev Only callable by a wearer of the OWNER_HAT
+   * @dev Only callable by a wearer of the ownerHat
    *      Does not revert if an account is not yet added
    * @param _accounts The array of accounts to remove
    */
@@ -262,7 +262,7 @@ contract AllowlistEligibility is HatsEligibilityModule {
 
   /**
    * @notice Set the standing for an account
-   * @dev Only callable by a wearer of the ARBITRATOR_HAT
+   * @dev Only callable by a wearer of the arbitratorHat
    *      Does not revert if an account is not yet added
    * @param _account The account to set standing for
    * @param _standing The standing to set
@@ -275,7 +275,7 @@ contract AllowlistEligibility is HatsEligibilityModule {
 
   /**
    * @notice Puts an account in bad standing and burns their hat
-   * @dev Only callable by a wearer of the ARBITRATOR_HAT
+   * @dev Only callable by a wearer of the arbitratorHat
    *      Reverts if the account is not wearing the hat, but otherwise does not revert if an account is not yet added
    * @param _account The account to set standing for
    */
@@ -299,7 +299,7 @@ contract AllowlistEligibility is HatsEligibilityModule {
 
   /**
    * @notice Set the standing for multiple accounts
-   * @dev Only callable by a wearer of the ARBITRATOR_HAT
+   * @dev Only callable by a wearer of the arbitratorHat
    *      Does not revert if an account is not yet added
    * @param _accounts The array of accounts to set standing for
    * @param _standing The array of standings to set, indexed to the accounts array
@@ -384,13 +384,13 @@ contract AllowlistEligibility is HatsEligibilityModule {
                             MODIFERS
   //////////////////////////////////////////////////////////////*/
 
-  /// @notice Reverts if the caller is not wearing the OWNER_HAT.
+  /// @notice Reverts if the caller is not wearing the ownerHat.
   modifier onlyOwner() {
     if (!HATS().isWearerOfHat(msg.sender, ownerHat)) revert AllowlistEligibility_NotOwner();
     _;
   }
 
-  /// @notice Reverts if the caller is not wearing the ARBITRATOR_HAT.
+  /// @notice Reverts if the caller is not wearing the arbitratorHat.
   modifier onlyArbitrator() {
     if (!HATS().isWearerOfHat(msg.sender, arbitratorHat)) revert AllowlistEligibility_NotArbitrator();
     _;

--- a/src/AllowlistEligibility.sol
+++ b/src/AllowlistEligibility.sol
@@ -122,15 +122,28 @@ contract AllowlistEligibility is HatsEligibilityModule {
 
   /// @inheritdoc HatsModule
   function _setUp(bytes calldata _initData) internal override {
+    uint256 _ownerHat;
+    uint256 _arbitratorHat;
+
     // if there are no initial accounts to add, only set the owner and arbitrator hats
     if (_initData.length < 65) {
-      (ownerHat, arbitratorHat) = abi.decode(_initData, (uint256, uint256));
+      // decode init data to look for hats
+      (_ownerHat, _arbitratorHat) = abi.decode(_initData, (uint256, uint256));
+
+      // set the owner and arbitrator hats
+      _setOwnerHat(_ownerHat);
+      _setArbitratorHat(_arbitratorHat);
+
       return;
     }
 
     // otherwise, decode init data to look for hats and initial accounts to add
     address[] memory _accounts;
-    (ownerHat, arbitratorHat, _accounts) = abi.decode(_initData, (uint256, uint256, address[]));
+    (_ownerHat, _arbitratorHat, _accounts) = abi.decode(_initData, (uint256, uint256, address[]));
+
+    // set the owner and arbitrator hats
+    _setOwnerHat(_ownerHat);
+    _setArbitratorHat(_arbitratorHat);
 
     // add initial accounts to allowlist
     _addAccountsMemory(_accounts);
@@ -305,12 +318,22 @@ contract AllowlistEligibility is HatsEligibilityModule {
     emit AccountsStandingChanged(_accounts, _standing);
   }
 
+  /**
+   * @notice Set a new owner hat
+   * @dev Only callable by a wearer of the current ownerHat, and only if the target hat is mutable
+   * @param _newOwnerHat The new owner hat
+   */
   function setOwnerHat(uint256 _newOwnerHat) public onlyOwner hatIsMutable {
     ownerHat = _newOwnerHat;
 
     emit OwnerHatSet(_newOwnerHat);
   }
 
+  /**
+   * @notice Set a new arbitrator hat
+   * @dev Only callable by a wearer of the current arbitratorHat, and only if the target hat is mutable
+   * @param _newArbitratorHat The new arbitrator hat
+   */
   function setArbitratorHat(uint256 _newArbitratorHat) public onlyOwner hatIsMutable {
     arbitratorHat = _newArbitratorHat;
 
@@ -335,6 +358,26 @@ contract AllowlistEligibility is HatsEligibilityModule {
     }
 
     emit AccountsAdded(_accounts);
+  }
+
+  /**
+   * @dev Set a new owner hat
+   * @param _newOwnerHat The new owner hat
+   */
+  function _setOwnerHat(uint256 _newOwnerHat) public {
+    ownerHat = _newOwnerHat;
+
+    emit OwnerHatSet(_newOwnerHat);
+  }
+
+  /**
+   * @dev Set a new arbitrator hat
+   * @param _newArbitratorHat The new arbitrator hat
+   */
+  function _setArbitratorHat(uint256 _newArbitratorHat) public {
+    arbitratorHat = _newArbitratorHat;
+
+    emit ArbitratorHatSet(_newArbitratorHat);
   }
 
   /*//////////////////////////////////////////////////////////////

--- a/test/AllowlistEligibility.t.sol
+++ b/test/AllowlistEligibility.t.sol
@@ -91,10 +91,10 @@ contract WithInstanceTest is AllowlistEligibilityTest {
     vm.stopPrank();
 
     // set up the other immutable args
-    otherImmutableArgs = abi.encodePacked(ownerHat, arbitratorHat);
+    otherImmutableArgs = abi.encodePacked();
 
     // set up the init args
-    initArgs = abi.encode();
+    initArgs = abi.encode(ownerHat, arbitratorHat);
 
     // deploy an instance of the module
     instance = AllowlistEligibility(
@@ -129,11 +129,11 @@ contract Deployment is WithInstanceTest {
 
     // implementation
     vm.expectRevert();
-    AllowlistEligibility(implementation).setUp(abi.encode(alloweds));
+    AllowlistEligibility(implementation).setUp(abi.encode(ownerHat, arbitratorHat, alloweds));
 
     // instance
     vm.expectRevert();
-    instance.setUp(abi.encode(alloweds));
+    instance.setUp(abi.encode(ownerHat, arbitratorHat, alloweds));
   }
 
   function test_version() public {
@@ -153,11 +153,11 @@ contract Deployment is WithInstanceTest {
   }
 
   function test_ownerHat() public {
-    assertEq(instance.OWNER_HAT(), ownerHat);
+    assertEq(instance.ownerHat(), ownerHat);
   }
 
   function test_arbitratorHat() public {
-    assertEq(instance.ARBITRATOR_HAT(), arbitratorHat);
+    assertEq(instance.arbitratorHat(), arbitratorHat);
   }
 }
 

--- a/test/AllowlistEligibility.t.sol
+++ b/test/AllowlistEligibility.t.sol
@@ -7,7 +7,8 @@ import {
   AllowlistEligibility_NotOwner,
   AllowlistEligibility_NotArbitrator,
   AllowlistEligibility_NotWearer,
-  AllowlistEligibility_ArrayLengthMismatch
+  AllowlistEligibility_ArrayLengthMismatch,
+  AllowlistEligibility_HatNotMutable
 } from "../src/AllowlistEligibility.sol";
 import { Deploy, DeployPrecompiled } from "../script/Deploy.s.sol";
 import {
@@ -56,6 +57,8 @@ contract AllowlistEligibilityTest is Deploy, Test {
   event AccountsRemoved(address[] accounts);
   event AccountStandingChanged(address account, bool standing);
   event AccountsStandingChanged(address[] accounts, bool[] standing);
+  event OwnerHatSet(uint256 newOwnerHat);
+  event ArbitratorHatSet(uint256 newArbitratorHat);
 
   // Hats events
   event TransferSingle(address indexed operator, address indexed from, address indexed to, uint256 id, uint256 amount);
@@ -537,5 +540,67 @@ contract SetBadStandingAndBurnHat is WithInstanceTest {
 
     stateAssertions(allowed1, true, true);
     moduleAssertions(allowed1, true, true);
+  }
+}
+
+contract SetOwnerHat is WithInstanceTest {
+  function test_owner_mutable() public {
+    uint256 newOwnerHat = 1;
+    vm.expectEmit();
+    emit OwnerHatSet(newOwnerHat);
+
+    vm.prank(owner);
+    instance.setOwnerHat(newOwnerHat);
+  }
+
+  function test_revert_nonOwner_mutable() public {
+    uint256 newOwnerHat = 1;
+    vm.expectRevert(AllowlistEligibility_NotOwner.selector);
+
+    vm.prank(nonWearer);
+    instance.setOwnerHat(newOwnerHat);
+  }
+
+  function test_revert_owner_immutable() public {
+    uint256 newOwnerHat = 1;
+
+    vm.prank(org);
+    HATS.makeHatImmutable(hatToClaim);
+
+    vm.expectRevert(AllowlistEligibility_HatNotMutable.selector);
+
+    vm.prank(owner);
+    instance.setOwnerHat(newOwnerHat);
+  }
+}
+
+contract SetArbitratorHat is WithInstanceTest {
+  function test_owner_mutable() public {
+    uint256 newArbitratorHat = 1;
+    vm.expectEmit();
+    emit ArbitratorHatSet(newArbitratorHat);
+
+    vm.prank(owner);
+    instance.setArbitratorHat(newArbitratorHat);
+  }
+
+  function test_revert_nonOwner_mutable() public {
+    uint256 newArbitratorHat = 1;
+    vm.expectRevert(AllowlistEligibility_NotOwner.selector);
+
+    vm.prank(nonWearer);
+    instance.setArbitratorHat(newArbitratorHat);
+  }
+
+  function test_revert_owner_immutable() public {
+    uint256 newArbitratorHat = 1;
+
+    vm.prank(org);
+    HATS.makeHatImmutable(hatToClaim);
+
+    vm.expectRevert(AllowlistEligibility_HatNotMutable.selector);
+
+    vm.prank(owner);
+    instance.setArbitratorHat(newArbitratorHat);
   }
 }


### PR DESCRIPTION
Converts ownerHat and arbitratorHat from immutable "constants" to mutable storage values. 

The reason to do this is that this module is stateful, which adds friction to migrating to a new instance in order to update owner or arbitrator roles.

There are two primary benefits of immutable config on modules
1. simple to understand when/how they can be updated, ie by an admin of the hat as long as the hat is mutable
2. some gas savings by using immutable values instead of storage reads

We can get the benefits of (1) in a mutable scenario by constraining changes to when the hat is mutable.